### PR TITLE
SNMP Stats

### DIFF
--- a/src/007/linuxproc.go
+++ b/src/007/linuxproc.go
@@ -12,6 +12,7 @@ const (
 	NetworkStatPath  = "/proc/net/dev"
 	NetstatStatPath  = "/proc/net/netstat"
 	SockstatStatPath = "/proc/net/sockstat"
+	SnmpStatPath     = "/proc/net/snmp"
 )
 
 type Stat struct {
@@ -79,6 +80,26 @@ func getSockstatStatsList() []Stat {
 	for i := 0; i < elem.NumField(); i++ {
 		field := typeOfElem.Field(i)
 		list = append(list, Stat{field.Name, strings.Join([]string{sockstatStatsMetricPrefix, field.Tag.Get("json")}, "")})
+	}
+
+	return list
+}
+
+func readSnmpStats() (*linuxproc.Snmp, error) {
+	return linuxproc.ReadSnmp(SnmpStatPath)
+}
+
+func getSnmpStatsList() []Stat {
+	stat := linuxproc.Snmp{}
+
+	elem := reflect.ValueOf(&stat).Elem()
+	typeOfElem := elem.Type()
+
+	list := make([]Stat, 0)
+
+	for i := 0; i < elem.NumField(); i++ {
+		field := typeOfElem.Field(i)
+		list = append(list, Stat{field.Name, strings.Join([]string{snmpStatsMetricPrefix, field.Tag.Get("json")}, "")})
 	}
 
 	return list

--- a/src/007/main.go
+++ b/src/007/main.go
@@ -85,6 +85,10 @@ func main() {
 			fmt.Println(stat.StatName + ":" + stat.MetricName)
 		}
 		fmt.Println("<---")
+		fmt.Println(SnmpStatPath)
+		for _, stat := range getSnmpStatsList() {
+			fmt.Println(stat.StatName + ":" + stat.MetricName)
+		}
 		os.Exit(0)
 	}
 
@@ -191,6 +195,7 @@ func startLoggers() {
 				logNetworkDeviceStats()
 				logNetstatStats()
 				logSockstatStats()
+				logSnmpStats()
 			}
 		}
 	})
@@ -206,6 +211,7 @@ func startCollectors() {
 				collectNetworkDeviceStats()
 				collectNetstatStats()
 				collectSockstatStats()
+				collectSnmpStats()
 			}
 		}
 	})

--- a/src/007/statsd.go
+++ b/src/007/statsd.go
@@ -12,6 +12,7 @@ const (
 	networkDeviceStatsMetricPrefix = "net.dev."
 	netstatStatsMetricPrefix       = "net.netstat."
 	sockstatStatsMetricPrefix      = "net.sockstat."
+	snmpStatsMetricPrefix          = "net.snmp."
 )
 
 type LoggedStat struct {
@@ -145,6 +146,48 @@ func logSockstatStats() {
 	}
 
 	loggedStat := LoggedStat{SockstatStatPath, time.Now(), stats}
+
+	jsonBytes, err := json.Marshal(loggedStat)
+	if err != nil {
+		Log.WithField("error", err).Errorf("Error JSON marshalling: %+v.", stats)
+	}
+
+	fmt.Println(string(jsonBytes))
+}
+
+func collectSnmpStats() {
+	stats, err := readSnmpStats()
+
+	if err != nil {
+		Log.WithField("error", err).Error("Error reading snmp stats. Can't collect netstat stats.")
+	}
+
+	elem := reflect.ValueOf(stats).Elem()
+	typeOfElem := elem.Type()
+
+	for i := 0; i < elem.NumField(); i++ {
+		field := typeOfElem.Field(i)
+
+		value := elem.Field(i).Uint()
+
+		_, collect := StatsMap[field.Name]
+
+		if metricName := field.Tag.Get("json"); collect && metricName != "" {
+			if err := StatsdClient.Gauge(strings.Join([]string{snmpStatsMetricPrefix, metricName}, ""), float64(value), []string{}, 1); err != nil {
+				Log.WithField("error", err).Error("Couldn't submit event to statsd.")
+			}
+		}
+	}
+}
+
+func logSnmpStats() {
+	stats, err := readSnmpStats()
+
+	if err != nil {
+		Log.WithField("error", err).Error("Error reading snmp stats. Can't log netstat stats.")
+	}
+
+	loggedStat := LoggedStat{SnmpStatPath, time.Now(), stats}
 
 	jsonBytes, err := json.Marshal(loggedStat)
 	if err != nil {


### PR DESCRIPTION
@Shopify/traffic 

Adds logging and collecting of stats from /proc/net/snmp.

Can't be merged at this point: waiting on the merging of [this pull request](https://github.com/c9s/goprocinfo/pull/34), then the dependency must be updated in the vendor manifest.

Tested on a remote server (with the modified goprocinfo).