### PR TITLE
Add .editorconfig and set indent_size to 4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# See http://editorconfig.org
+
+# In Go files we indent with tabs but still 
+# set indent_size to control the GitHub web viewer.  
+[*.go]
+indent_size=4
+


### PR DESCRIPTION
I saw that the repository doesn't have a config file for specifying GitHub to treat tabs with less than 8 spaces, which is GitHub's default behavior.

This PR changes this default behavior and introduces the possibility to specify the number of spaces GitHub to use as indent size for *.go files. 